### PR TITLE
fix(select): replace CSS-gradient chevron with SVG mask-image

### DIFF
--- a/components/components.css
+++ b/components/components.css
@@ -258,15 +258,35 @@
   --ct-control-padding-y: var(--space-5);
 }
 
+.ct-select-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.ct-select-wrap::after {
+  content: '';
+  position: absolute;
+  inset-inline-end: var(--space-4);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0.75em;
+  height: 0.5em;
+  background-color: var(--color-text-muted);
+  --_chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8'%3E%3Cpath d='M1.4 0L6 4.6 10.6 0 12 1.4l-6 6-6-6z'/%3E%3C/svg%3E");
+  -webkit-mask-image: var(--_chevron);
+  mask-image: var(--_chevron);
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  pointer-events: none;
+}
+
+.ct-select-wrap > .ct-select {
+  width: 100%;
+}
+
 .ct-select {
   appearance: none;
-  background-image: linear-gradient(45deg, transparent 50%, var(--color-text-muted) 50%),
-    linear-gradient(135deg, var(--color-text-muted) 50%, transparent 50%);
-  background-position: calc(100% - var(--space-6)) 50%,
-    calc(100% - var(--space-5)) 50%;
-  background-size: 6px 6px, 6px 6px;
-  background-repeat: no-repeat;
-  padding-right: calc(var(--space-8) + var(--space-6));
+  padding-inline-end: calc(var(--space-4) + 0.75em + var(--space-4));
 }
 
 .ct-input--with-icon {

--- a/stories/DataTable.stories.js
+++ b/stories/DataTable.stories.js
@@ -20,18 +20,22 @@ export const DataTable = {
     <div class="ct-data-table__toolbar">
       <div class="ct-data-table__filters">
         <input class="ct-input ct-control--sm ct-data-table__search" placeholder="Search projects" aria-label="Search projects" />
-        <select class="ct-select ct-control--sm" aria-label="Filter by status">
-          <option>Status</option>
-          <option>Active</option>
-          <option>Paused</option>
-          <option>Archived</option>
-        </select>
-        <select class="ct-select ct-control--sm" aria-label="Filter by owner">
-          <option>Owner</option>
-          <option>J. Chen</option>
-          <option>L. Hart</option>
-          <option>S. Rivera</option>
-        </select>
+        <div class="ct-select-wrap">
+          <select class="ct-select ct-control--sm" aria-label="Filter by status">
+            <option>Status</option>
+            <option>Active</option>
+            <option>Paused</option>
+            <option>Archived</option>
+          </select>
+        </div>
+        <div class="ct-select-wrap">
+          <select class="ct-select ct-control--sm" aria-label="Filter by owner">
+            <option>Owner</option>
+            <option>J. Chen</option>
+            <option>L. Hart</option>
+            <option>S. Rivera</option>
+          </select>
+        </div>
       </div>
       <div class="ct-data-table__actions">
         <button class="ct-button ct-button--ghost ct-button--sm">Reset</button>
@@ -110,11 +114,13 @@ export const DataTable = {
       <div class="ct-data-table__footer-actions">
         <div class="ct-data-table__page-size">
           <span>Rows</span>
-          <select class="ct-select ct-control--sm" aria-label="Rows per page">
-            <option>10</option>
-            <option>25</option>
-            <option>50</option>
-          </select>
+          <div class="ct-select-wrap">
+            <select class="ct-select ct-control--sm" aria-label="Rows per page">
+              <option>10</option>
+              <option>25</option>
+              <option>50</option>
+            </select>
+          </div>
         </div>
         <nav class="ct-pagination" aria-label="Data table pagination">
           <ul class="ct-pagination__list">

--- a/stories/FormControls.stories.js
+++ b/stories/FormControls.stories.js
@@ -23,11 +23,13 @@ export const Fields = {
 
     <div class="ct-field">
       <label class="ct-field__label" for="role">Role</label>
-      <select class="ct-select" id="role">
-        <option>Designer</option>
-        <option>Engineer</option>
-        <option>Manager</option>
-      </select>
+      <div class="ct-select-wrap">
+        <select class="ct-select" id="role">
+          <option>Designer</option>
+          <option>Engineer</option>
+          <option>Manager</option>
+        </select>
+      </div>
     </div>
 
     <div class="ct-field">


### PR DESCRIPTION
## Summary
- Replace the fragile two-gradient triangle chevron hack (magic numbers, breaks at zoom) with a clean SVG data-URI using `mask-image` on a `::after` pseudo-element
- Introduce `.ct-select-wrap` wrapper (follows existing `.ct-input-wrap` pattern) — chevron color adapts to all themes automatically via `background-color: var(--color-text-muted)`
- Use `em`-based sizing (scales with font/zoom), `inset-inline-end` (RTL-safe), and logical `padding-inline-end`

## Test plan
- [x] All 48 existing tests pass
- [ ] Visual check: chevron renders correctly in light, dark, and high-contrast themes
- [ ] Verify chevron scales properly at different zoom levels

Closes #13