### PR TITLE
fix(toast): use logical border property and add reduced-motion support

### DIFF
--- a/components/components.css
+++ b/components/components.css
@@ -682,7 +682,7 @@ th[aria-sort='descending'] .ct-table__sort-indicator::after {
   border-radius: var(--radius-md);
   background: var(--color-bg-elevated);
   border: var(--border-thin) solid var(--color-border-subtle);
-  border-left: 4px solid var(--ct-toast-accent);
+  border-inline-start: var(--border-thick) solid var(--ct-toast-accent);
   box-shadow: var(--shadow-md);
   color: var(--color-text-primary);
   transition: opacity var(--duration-fast) var(--easing-standard),
@@ -725,6 +725,12 @@ th[aria-sort='descending'] .ct-table__sort-indicator::after {
   --ct-toast-accent: var(--color-state-danger);
   background: var(--color-state-danger-surface);
   border-color: var(--color-state-danger-border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ct-toast {
+    transition: none;
+  }
 }
 
 .ct-tooltip {


### PR DESCRIPTION
## Summary
- Replace `border-left` with `border-inline-start` so the accent stripe renders correctly in RTL layouts
- Replace hardcoded `4px` border width with the `--border-thick` design token
- Add `prefers-reduced-motion: reduce` media query to disable toast transitions for users who prefer reduced motion

## Test plan
- [ ] Verify toast accent border appears on the correct side in both LTR and RTL contexts
- [ ] Confirm `--border-thick` token resolves to `3px` and the visual result is acceptable
- [ ] Test with `prefers-reduced-motion: reduce` enabled — toast should not animate

Closes #18