### PR TITLE
fix(checkbox/radio): logical props, focus ring, indeterminate state

### DIFF
--- a/components/components.css
+++ b/components/components.css
@@ -349,8 +349,8 @@
   width: 10px;
   height: 6px;
   border: 2px solid var(--color-text-inverse);
-  border-top: 0;
-  border-right: 0;
+  border-block-start: 0;
+  border-inline-end: 0;
   transform: rotate(-45deg) scale(0);
   transition: transform var(--duration-fast) var(--easing-standard);
 }
@@ -359,7 +359,7 @@
   content: '';
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-round);
   background: var(--color-text-inverse);
   transform: scale(0);
   transition: transform var(--duration-fast) var(--easing-standard);
@@ -380,6 +380,26 @@
 .ct-radio__input:disabled {
   background: var(--color-bg-muted);
   border-color: var(--color-border-subtle);
+}
+
+.ct-check__input:focus-visible,
+.ct-radio__input:focus-visible {
+  border-color: var(--ct-control-border-focus);
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.ct-check__input:indeterminate {
+  background: var(--color-brand-primary);
+  border-color: var(--color-brand-primary);
+}
+
+.ct-check__input:indeterminate::before {
+  width: 10px;
+  height: 0;
+  border-block-start: 2px solid var(--color-text-inverse);
+  border-inline-end: 0;
+  transform: scale(1);
 }
 
 .ct-switch {


### PR DESCRIPTION
## Summary
- Replace physical CSS properties (`border-top`, `border-right`) with logical equivalents (`border-block-start`, `border-inline-end`) for RTL support
- Replace hardcoded `border-radius: 999px` on radio dot with `var(--radius-round)` token
- Add `:focus-visible` ring for `.ct-check__input` and `.ct-radio__input` using existing `--ct-control-border-focus` and `--color-focus-ring` tokens
- Add `:indeterminate` checkbox state with proper logical properties

Closes #21

## Test plan
- [ ] Verify checkbox check mark renders correctly in LTR and RTL layouts
- [ ] Verify radio dot renders correctly in both directions
- [ ] Tab to checkbox/radio and confirm focus ring appears
- [ ] Set a checkbox to indeterminate via JS (`el.indeterminate = true`) and verify the dash indicator
- [ ] Run `npx vitest --run` to confirm no regressions
- [ ] Confirm Storybook a11y addon passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)