### PR TITLE
fix(switch): add focus ring, size variants, use token for border-radius

### DIFF
--- a/components/components.css
+++ b/components/components.css
@@ -410,7 +410,7 @@
   inset-inline-start: 2px;
   width: calc(var(--ct-switch-height) - 4px);
   height: calc(var(--ct-switch-height) - 4px);
-  border-radius: 999px;
+  border-radius: var(--radius-round);
   background: var(--color-bg-elevated);
   box-shadow: var(--shadow-xs);
   transition: transform var(--duration-fast) var(--easing-standard);
@@ -426,6 +426,21 @@
 
 .ct-switch__input:disabled {
   background: var(--color-border-subtle);
+}
+
+.ct-switch__input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.ct-switch--sm .ct-switch__input {
+  --ct-switch-width: 36px;
+  --ct-switch-height: 20px;
+}
+
+.ct-switch--lg .ct-switch__input {
+  --ct-switch-width: 52px;
+  --ct-switch-height: 28px;
 }
 
 .ct-card__header {


### PR DESCRIPTION
## Summary
- Replaced hardcoded `border-radius: 999px` on the switch thumb with `var(--radius-round)` design token
- Added `:focus-visible` outline ring (`2px solid var(--color-focus-ring)`) for keyboard accessibility
- Added `--sm` (36x20px) and `--lg` (52x28px) size variants via `.ct-switch--sm` and `.ct-switch--lg` modifier classes

## Test plan
- [ ] Verify switch renders correctly at default, `--sm`, and `--lg` sizes
- [ ] Verify focus ring appears on keyboard tab navigation
- [ ] Verify switch thumb remains circular (border-radius via token)
- [ ] Run `npx vitest --run` to confirm no regressions

Closes #19