### PR TITLE
docs: resolve #2 – add MDX documentation pages

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,6 @@
 /** @type { import('@storybook/html-vite').StorybookConfig } */
 const config = {
-  stories: ['../stories/**/*.stories.@(js|mdx)'],
+  stories: ['../stories/**/*.stories.js', '../stories/docs/*.mdx'],
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-docs',

--- a/stories/docs/Accessibility.mdx
+++ b/stories/docs/Accessibility.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Docs/Accessibility Guidelines" tags={['!autodocs']} />
 

--- a/stories/docs/ComponentPatterns.mdx
+++ b/stories/docs/ComponentPatterns.mdx
@@ -1,0 +1,282 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Component Patterns" tags={['!autodocs']} />
+
+# Component Patterns
+
+This page documents the conventions that all Construct components follow: BEM naming, state management through data attributes and ARIA, sizing, and composition.
+
+---
+
+## BEM Naming Convention
+
+Every component uses the `ct-` prefix with BEM (Block Element Modifier) structure:
+
+```
+ct-{block}
+ct-{block}__{element}
+ct-{block}--{modifier}
+```
+
+### Blocks
+
+A block is a standalone component. It carries the `ct-` prefix:
+
+```html
+<button class="ct-button">Save</button>
+<div class="ct-card">...</div>
+<div class="ct-modal">...</div>
+```
+
+### Elements
+
+An element is a child of a block, separated by double underscores (`__`):
+
+```html
+<div class="ct-card">
+  <div class="ct-card__header">Title</div>
+  <div class="ct-card__body">Content</div>
+  <div class="ct-card__footer">Actions</div>
+</div>
+```
+
+Elements are always scoped to their block. Never nest element selectors (`ct-card__header__title` is wrong — use a new block or a simple child element instead).
+
+### Modifiers
+
+A modifier changes appearance or behaviour, separated by double dashes (`--`):
+
+```html
+<!-- Variant modifiers -->
+<button class="ct-button ct-button--secondary">Cancel</button>
+<button class="ct-button ct-button--danger">Delete</button>
+<button class="ct-button ct-button--ghost">Skip</button>
+
+<!-- Size modifiers -->
+<button class="ct-button ct-button--sm">Small</button>
+<button class="ct-button ct-button--lg">Large</button>
+```
+
+The base class is always required alongside the modifier.
+
+---
+
+## Sizing
+
+Components support three sizes via modifier classes:
+
+| Modifier | Size | Usage |
+|----------|------|-------|
+| `--sm` | Small | Dense UIs, inline actions |
+| *(default)* | Medium | Standard use |
+| `--lg` | Large | Primary actions, touch targets |
+
+Sizing is consistent across related components — a `ct-button--sm` aligns visually with a `ct-input--sm` in the same form row.
+
+---
+
+## State Management
+
+Construct uses **HTML attributes** — not CSS classes — for all interactive state. This makes state queryable, accessible, and framework-independent.
+
+### Data attributes
+
+| Attribute | Values | Components |
+|-----------|--------|------------|
+| `data-state` | `"open"`, `"closed"` | Modal, dropdown, tooltip, sidebar, datepicker |
+| `data-variant` | `"info"`, `"success"`, `"warning"`, `"danger"` | Toast, alert, badge, confirmation |
+| `data-status` | `"success"`, `"error"` | File upload items |
+| `data-side` | `"top"`, `"bottom"`, `"left"`, `"right"` | Tooltip |
+| `data-today` | `"true"` | Datepicker day |
+| `data-outside` | `"true"` | Datepicker day (other month) |
+
+```html
+<!-- Closed dropdown -->
+<div class="ct-dropdown">
+  <button aria-expanded="false">Options</button>
+  <ul class="ct-dropdown__menu" data-state="closed">...</ul>
+</div>
+
+<!-- Open dropdown -->
+<div class="ct-dropdown">
+  <button aria-expanded="true">Options</button>
+  <ul class="ct-dropdown__menu" data-state="open">...</ul>
+</div>
+```
+
+### ARIA attributes for state
+
+These standard ARIA attributes double as CSS selectors:
+
+| Attribute | Purpose | CSS selector |
+|-----------|---------|-------------|
+| `aria-expanded` | Open/closed state for triggers | `[aria-expanded="true"]` |
+| `aria-selected` | Selected tab, option, or day | `[aria-selected="true"]` |
+| `aria-invalid` | Form validation error | `[aria-invalid="true"]` |
+| `aria-pressed` | Toggle button state | `[aria-pressed="true"]` |
+| `aria-disabled` | Disabled but still focusable | `[aria-disabled="true"]` |
+| `aria-current` | Current page in navigation | `[aria-current="page"]` |
+
+```css
+/* Construct styles state via ARIA selectors */
+.ct-input[aria-invalid="true"] {
+  border-color: var(--color-state-danger);
+}
+
+.ct-tabs__trigger[aria-selected="true"] {
+  border-bottom-color: var(--color-brand-primary);
+}
+```
+
+### Why attributes over classes?
+
+- **Accessible by default** — screen readers already understand `aria-expanded`. A `.is-open` class would require separate ARIA wiring
+- **Queryable** — `element.getAttribute('aria-expanded')` works in any framework
+- **Single source of truth** — the attribute is both the style hook and the accessibility signal
+
+---
+
+## ARIA Patterns by Component
+
+### Tabs
+
+Roving tabindex with arrow-key navigation. The active tab has `tabindex="0"`, all others `tabindex="-1"`.
+
+```html
+<div class="ct-tabs">
+  <div class="ct-tabs__list" role="tablist">
+    <button class="ct-tabs__trigger" role="tab"
+            aria-selected="true" tabindex="0"
+            aria-controls="panel-1">Tab 1</button>
+    <button class="ct-tabs__trigger" role="tab"
+            aria-selected="false" tabindex="-1"
+            aria-controls="panel-2">Tab 2</button>
+  </div>
+  <div class="ct-tabs__panel" role="tabpanel" id="panel-1">Content 1</div>
+  <div class="ct-tabs__panel" role="tabpanel" id="panel-2" hidden>Content 2</div>
+</div>
+```
+
+### Modal
+
+Focus is trapped inside. Focus returns to the trigger on close.
+
+```html
+<div class="ct-modal" data-state="open">
+  <div class="ct-modal__dialog" role="dialog"
+       aria-modal="true" aria-labelledby="modal-title">
+    <div class="ct-modal__header">
+      <h2 id="modal-title">Confirm</h2>
+      <button class="ct-button ct-button--ghost ct-button--icon"
+              aria-label="Close">...</button>
+    </div>
+    <div class="ct-modal__body">Are you sure?</div>
+    <div class="ct-modal__footer">
+      <button class="ct-button ct-button--secondary">Cancel</button>
+      <button class="ct-button">Confirm</button>
+    </div>
+  </div>
+</div>
+```
+
+### Dropdown
+
+Trigger toggles `aria-expanded`. Menu items are focusable buttons in natural tab order.
+
+```html
+<div class="ct-dropdown">
+  <button aria-expanded="false" aria-controls="menu-1"
+          aria-haspopup="true">Options</button>
+  <ul class="ct-dropdown__menu" id="menu-1"
+      role="list" data-state="closed">
+    <li><button class="ct-dropdown__item">Edit</button></li>
+    <li><button class="ct-dropdown__item">Delete</button></li>
+  </ul>
+</div>
+```
+
+### Accordion
+
+Uses native `<details>` elements. No JavaScript required for basic functionality.
+
+```html
+<div class="ct-accordion">
+  <details class="ct-accordion__item">
+    <summary class="ct-accordion__trigger">
+      <span class="ct-accordion__heading">Section title</span>
+      <span class="ct-accordion__icon" aria-hidden="true"></span>
+    </summary>
+    <div class="ct-accordion__content">Panel content</div>
+  </details>
+</div>
+```
+
+### Form fields
+
+Labels, hints, and errors are linked via `for`, `id`, and `aria-describedby`:
+
+```html
+<div class="ct-field">
+  <label class="ct-field__label" for="email">Email</label>
+  <span class="ct-field__hint" id="email-hint">We'll never share your email</span>
+  <input class="ct-input" type="email" id="email"
+         aria-describedby="email-hint" />
+</div>
+
+<!-- With validation error -->
+<div class="ct-field">
+  <label class="ct-field__label" for="name">Name</label>
+  <input class="ct-input" id="name"
+         aria-invalid="true" aria-describedby="name-error" />
+  <span class="ct-field__error" id="name-error">Name is required</span>
+</div>
+```
+
+---
+
+## Composition
+
+Components are designed to nest naturally:
+
+```html
+<!-- Card containing a form -->
+<div class="ct-card">
+  <div class="ct-card__header">User Settings</div>
+  <div class="ct-card__body">
+    <div class="ct-stack" style="--ct-stack-space: var(--space-6)">
+      <div class="ct-field">
+        <label class="ct-field__label" for="name">Name</label>
+        <input class="ct-input" id="name" />
+      </div>
+      <div class="ct-field">
+        <label class="ct-field__label" for="bio">Bio</label>
+        <textarea class="ct-textarea" id="bio"></textarea>
+      </div>
+    </div>
+  </div>
+  <div class="ct-card__footer">
+    <div class="ct-cluster">
+      <button class="ct-button ct-button--secondary">Cancel</button>
+      <button class="ct-button">Save</button>
+    </div>
+  </div>
+</div>
+```
+
+### Layout utilities
+
+| Class | Purpose |
+|-------|---------|
+| `ct-stack` | Vertical spacing between children (set `--ct-stack-space`) |
+| `ct-cluster` | Horizontal wrapping layout (set `--ct-cluster-space`) |
+| `ct-sr-only` | Visually hidden, accessible to screen readers |
+| `ct-truncate` | Single-line text truncation with ellipsis |
+| `ct-muted` | Muted text colour |
+
+---
+
+## Related
+
+- **[Design Principles](?path=/docs/docs-design-principles--docs)** — accessibility-first, token-based, framework-agnostic
+- **[Accessibility Guidelines](?path=/docs/docs-accessibility-guidelines--docs)** — keyboard patterns and testing checklist
+- **[Design Tokens](?path=/docs/docs-design-tokens--docs)** — full token reference

--- a/stories/docs/DesignPrinciples.mdx
+++ b/stories/docs/DesignPrinciples.mdx
@@ -1,0 +1,119 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Design Principles" tags={['!autodocs']} />
+
+# Design Principles
+
+Construct is built on three pillars: **accessibility first**, **token-based theming**, and **framework agnosticism**. Every decision — from API design to CSS architecture — flows from these principles.
+
+---
+
+## Accessibility First
+
+Accessibility is not an afterthought or a checkbox. It is the primary constraint that shapes every component.
+
+### What this means in practice
+
+- **Semantic HTML by default** — components use `<button>`, `<input>`, `<table>`, `<nav>`, `<details>` instead of generic `<div>` elements with ARIA bolted on
+- **Keyboard operable** — every interaction works without a mouse. Composite widgets (tabs, toolbars, dropdowns) implement roving tabindex and arrow-key navigation
+- **Visible focus indicators** — all interactive elements show a clear `:focus-visible` ring (2px solid, 2px offset)
+- **WCAG 2.1 AA contrast** — all three built-in themes meet minimum contrast ratios. The high-contrast theme exceeds AA
+- **State via ARIA attributes** — component states are expressed through `aria-expanded`, `aria-selected`, `aria-invalid`, and `aria-pressed` rather than visual-only CSS classes
+- **`prefers-reduced-motion` respected** — animations and transitions are disabled when the user's system preference says so
+
+### Why accessibility first?
+
+Building accessible components from the start is dramatically cheaper than retrofitting. When accessibility drives the API, the resulting components are more robust, more testable, and usable by the widest possible audience — including users of screen readers, keyboard-only users, and users with low vision.
+
+---
+
+## Token-Based Theming
+
+Every visual value in Construct — colors, spacing, typography, radii, shadows, motion — is expressed as a **design token**. No magic numbers, no hard-coded hex values.
+
+### Two-tier pipeline
+
+Construct uses a two-tier token system:
+
+1. **Primitives** — raw design values (`ocean.700: #174C5D`, `space.4: 8px`). These are the palette. They rarely change.
+2. **Semantic tokens** — purpose-driven aliases (`color.brand.primary → {color.ocean.700}`). These are what components consume. Swapping a theme means remapping semantic tokens while primitives stay untouched.
+
+### Benefits
+
+- **Consistency** — every component draws from the same set of values. No drift between a card's border radius and a modal's
+- **Theming** — switching from light to dark mode is a single `data-theme` attribute change. Every component updates simultaneously via CSS custom properties
+- **Customisation** — override a few semantic tokens to rebrand the entire system without touching component CSS
+- **Tooling** — tokens are available as CSS custom properties, JSON, and TypeScript exports. Use them at build time or runtime
+
+### Rules
+
+- Always use token references (`var(--color-text-primary)`) — never raw values
+- Add new tokens to the source JSON and run `npm run build`. Never hand-edit generated files
+- When in doubt, prefer an existing token over creating a new one
+
+---
+
+## Framework Agnostic
+
+Construct is pure CSS. It works with React, Angular, Svelte, Vue, Web Components, or plain HTML. There is no JavaScript runtime, no framework adapter, no build plugin.
+
+### How this works
+
+- Components are activated by CSS classes (`ct-button`, `ct-card`, `ct-input`)
+- State is driven by standard HTML attributes (`disabled`, `aria-expanded`, `data-state`)
+- Behaviour (keyboard handling, focus management) is the consumer's responsibility — Construct provides the styles and the patterns, not the JS
+
+### Why no JS?
+
+- **Zero lock-in** — migrate from React to Svelte without changing your design system
+- **Zero bundle cost** — CSS is loaded once and cached. No JS to parse, no hydration overhead
+- **Separation of concerns** — visual presentation (Construct) is decoupled from interaction logic (your framework)
+
+### Integration pattern
+
+```html
+<!-- Works everywhere -->
+<button class="ct-button ct-button--secondary">Cancel</button>
+```
+
+```jsx
+// React
+<button className="ct-button ct-button--secondary">Cancel</button>
+```
+
+```svelte
+<!-- Svelte -->
+<button class="ct-button ct-button--secondary">Cancel</button>
+```
+
+The same HTML structure and class names work in every framework.
+
+---
+
+## Additional Principles
+
+### Simplicity over cleverness
+
+- Flat CSS selectors — no deep nesting, no specificity wars
+- BEM naming — predictable, greppable, no collisions
+- Three-tier sizing (sm, md, lg) — enough flexibility without decision fatigue
+
+### Progressive enhancement
+
+- Components work without JavaScript. A `<details>` accordion, a native `<select>`, a `<button>` — all function before any script loads
+- JavaScript enhances: focus traps, roving tabindex, dynamic announcements via `aria-live`
+
+### Openness
+
+- Source tokens are human-readable JSON
+- Generated files (CSS, JSON, TypeScript) are committed so consumers can inspect exactly what they get
+- No proprietary toolchain — standard CSS, standard HTML, standard build scripts
+
+---
+
+## Related
+
+- **[Getting Started](?path=/docs/docs-getting-started--docs)** — installation and integration guide
+- **[Accessibility Guidelines](?path=/docs/docs-accessibility-guidelines--docs)** — detailed keyboard patterns and ARIA guidance
+- **[Design Tokens](?path=/docs/docs-design-tokens--docs)** — full token reference
+- **[Component Patterns](?path=/docs/docs-component-patterns--docs)** — BEM naming, state management, and ARIA patterns

--- a/stories/docs/DesignTokens.mdx
+++ b/stories/docs/DesignTokens.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Docs/Design Tokens" tags={['!autodocs']} />
 

--- a/stories/docs/GettingStarted.mdx
+++ b/stories/docs/GettingStarted.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Docs/Getting Started" tags={['!autodocs']} />
 

--- a/stories/docs/Theming.mdx
+++ b/stories/docs/Theming.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Docs/Theming" tags={['!autodocs']} />
 


### PR DESCRIPTION
## Summary
- **Design Principles** page: accessibility-first approach, token-based theming, framework-agnostic philosophy
- **Component Patterns** page: BEM naming convention, state management via data/ARIA attributes, ARIA patterns per component type
- **Fix MDX build** for Storybook 10: renamed `.stories.mdx` → `.mdx`, updated imports from `@storybook/blocks` to `@storybook/addon-docs/blocks`, updated story glob in `main.js`

All 5 suggested documentation pages from #2 are now complete:
1. Getting Started ✅ (existed)
2. Design Principles ✅ (new)
3. Token Reference ✅ (existed)
4. Theming Guide ✅ (existed)
5. Component Patterns ✅ (new)

Resolves #2

## Test plan
- [x] `npm run storybook:build` passes
- [ ] Verify all 6 MDX pages render in Storybook sidebar under "Docs"
- [ ] Verify cross-links between doc pages work
- [ ] Verify code examples render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)