### PR TITLE
fix(empty-state): replace non-existent danger token (resolve #73)

### DIFF
--- a/components/empty-state.css
+++ b/components/empty-state.css
@@ -84,11 +84,11 @@
 /* Variants */
 
 .ct-empty-state--error .ct-empty-state__icon {
-  color: var(--color-danger-text);
+  color: var(--color-state-danger);
 }
 
 .ct-empty-state--error .ct-empty-state__title {
-  color: var(--color-danger-text);
+  color: var(--color-state-danger);
 }
 
 .ct-empty-state--bordered {


### PR DESCRIPTION
## Summary
- Replace `--color-danger-text` (non-existent token) with `--color-state-danger` in the `--error` variant of EmptyState
- Fixes both the icon and title color declarations (lines 87, 91)
- Aligns with all other components that use `--color-state-danger` for danger/error coloring

Closes #73

## Test plan
- [ ] Verify EmptyState error variant renders icon and title in danger color
- [ ] Check rendering in light, dark, and high-contrast themes
- [ ] Confirm `npm run check` passes
- [ ] Confirm no visual regression in Storybook EmptyState stories