### PR TITLE
fix(a11y): add prefers-reduced-motion to file-upload component

### DIFF
--- a/components/file-upload.css
+++ b/components/file-upload.css
@@ -109,3 +109,9 @@
   color: var(--color-state-danger);
   font-size: var(--font-size-sm);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .ct-file-upload__dropzone {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `@media (prefers-reduced-motion: reduce)` rule to `file-upload.css` to disable dropzone transitions for users with motion sensitivity
- Aligns file-upload with all other animated components in the system that already respect this preference
- Resolves #72

## Test plan
- [x] `npm run check` passes (token outputs unchanged)
- [x] All 296 Storybook tests pass
- [ ] Verify in browser: enable "Reduce motion" in OS settings → file-upload dropzone hover/drag transitions should be instant